### PR TITLE
Add support for Partial Constructor application

### DIFF
--- a/src/PartialFunctions.jl
+++ b/src/PartialFunctions.jl
@@ -39,6 +39,7 @@ PartialFunctions.PartialFunction{typeof(println),Tuple{String}}
 """
 ($)(f::Function, args::Tuple) = PartialFunction(f, args)
 ($)(f::Function, arg) = PartialFunction(f, (arg,))
+($)(f::DataType, args) = ($)(identity∘f, args)
 
 """
     <|(f, args)


### PR DESCRIPTION
Composing identity∘f converts the Constructor f::DataType to a function, then calls ($) again to be handled properly.